### PR TITLE
Load switch pins from config

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,8 +1,8 @@
-
-from .gpio_controller import GPIOController, Bus, Pin
+from gpio_controller import GPIOController, Bus, Pin
 
 __all__ = [
     "GPIOController",
     "Bus",
     "Pin",
 ]
+

--- a/switch/multi_switch.py
+++ b/switch/multi_switch.py
@@ -5,7 +5,7 @@ from qcodes.instrument import InstrumentBaseKWArgs
 from qcodes.parameters import Parameter
 import qcodes.validators as vals
 
-from gpio_controller import Pin
+from gpio_controller import GPIOController, Bus
 from .abstract_switch import AbstractSwitch
 from .sp8t_switch import SP8T_Switch
 
@@ -16,22 +16,35 @@ class MultiSwitch(AbstractSwitch):
     def __init__(
         self,
         name: str,
-        main_switch: SP8T_Switch,
-        switch1: SP8T_Switch,
-        switch2: SP8T_Switch,
-        leds: tuple[Pin, ...],
+        controller: GPIOController,
         config_path: str,
         **kwargs: InstrumentBaseKWArgs,
     ) -> None:
         super().__init__(name, **kwargs)
-        self._main = main_switch
-        self._sw1 = switch1
-        self._sw2 = switch2
-        self._leds = leds
+
+        cfg = self._load_config(config_path)
+
+        pins = cfg["switches"]
+        self._main = SP8T_Switch(
+            f"{name}_main",
+            Bus(tuple(controller.modules[0].pins[p] for p in pins["main"])),
+        )
+        self._sw1 = SP8T_Switch(
+            f"{name}_sw1",
+            Bus(tuple(controller.modules[0].pins[p] for p in pins["sw1"])),
+        )
+        self._sw2 = SP8T_Switch(
+            f"{name}_sw2",
+            Bus(tuple(controller.modules[0].pins[p] for p in pins["sw2"])),
+        )
+
+        self._leds = tuple(
+            controller.modules[item["module"]].pins[item["pin"]]
+            for item in cfg["leds"]
+        )
         self._active_led = None
 
-        with open(config_path, "r", encoding="utf-8") as f:
-            self._state_map: list[dict[str, int]] = yaml.safe_load(f)["states"]
+        self._state_map: list[dict[str, int]] = cfg["states"]
 
         self._current_state = 0
         self.add_parameter("state", Parameter, get_cmd=self._get_state, set_cmd=self._set_state, vals=vals.Ints(0, len(self._state_map) - 1), unit="")
@@ -58,5 +71,10 @@ class MultiSwitch(AbstractSwitch):
             self._leds[self._active_led].state(0)
         self._leds[active].state(1)
         self._active_led = active
+
+    def _load_config(self, path: str) -> dict:
+        """Load YAML configuration."""
+        with open(path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
 
 

--- a/switch/switch_config.yaml
+++ b/switch/switch_config.yaml
@@ -1,3 +1,30 @@
+switches:
+  main: [2, 3, 4]
+  sw1: [5, 6, 7]
+  sw2: [8, 9, 10]
+leds:
+  - {module: 1, pin: 0}
+  - {module: 1, pin: 1}
+  - {module: 1, pin: 2}
+  - {module: 1, pin: 3}
+  - {module: 1, pin: 4}
+  - {module: 1, pin: 5}
+  - {module: 1, pin: 6}
+  - {module: 1, pin: 7}
+  - {module: 1, pin: 8}
+  - {module: 1, pin: 9}
+  - {module: 1, pin: 10}
+  - {module: 1, pin: 11}
+  - {module: 1, pin: 12}
+  - {module: 1, pin: 13}
+  - {module: 1, pin: 14}
+  - {module: 1, pin: 15}
+  - {module: 2, pin: 0}
+  - {module: 2, pin: 1}
+  - {module: 2, pin: 2}
+  - {module: 2, pin: 3}
+  - {module: 2, pin: 4}
+  - {module: 2, pin: 5}
 states:
   - {main: 1, sw1: 0}
   - {main: 1, sw1: 1}

--- a/test/test_multi_switch.py
+++ b/test/test_multi_switch.py
@@ -2,54 +2,60 @@ import unittest
 from pathlib import Path
 
 from switch.multi_switch import MultiSwitch
-from switch.sp8t_switch import SP8T_Switch
-from switch.abstract_switch import AbstractSwitch
-from gpio_controller import Bus
 
 
 class DummyPin:
     def __init__(self):
         self.val = 0
+
     def state(self, v=None):
         if v is None:
             return self.val
         self.val = v
 
 
-class DummySwitch(SP8T_Switch):
-    def __init__(self, name):
-        bus = Bus((DummyPin(), DummyPin(), DummyPin()))
-        super().__init__(name, bus)
+class DummyModule:
+    def __init__(self, count: int):
+        self.pins = [DummyPin() for _ in range(count)]
+
+
+class DummyController:
+    def __init__(self):
+        self.modules = (
+            DummyModule(11),
+            DummyModule(16),
+            DummyModule(16),
+        )
 
 
 class TestMultiSwitch(unittest.TestCase):
     def setUp(self):
-        self.main = DummySwitch("main")
-        self.s1 = DummySwitch("s1")
-        self.s2 = DummySwitch("s2")
-        self.leds = tuple(DummyPin() for _ in range(22))
+        self.ctrl = DummyController()
         config_path = Path(__file__).resolve().parent.parent / "switch" / "switch_config.yaml"
         self.ms = MultiSwitch(
             "multi",
-            self.main,
-            self.s1,
-            self.s2,
-            self.leds,
+            self.ctrl,
             config_path,
         )
+        self.led_pins = list(self.ms._leds)
 
     def test_state_mapping(self):
         self.ms.state(3)
-        self.assertEqual(self.main.state(), 1)
-        self.assertEqual(self.s1.state(), 3)
-        self.assertEqual(self.leds[3].val, 1)
-        self.assertTrue(all(led.val == (1 if idx == 3 else 0) for idx, led in enumerate(self.leds)))
+        self.assertEqual(self.ms._main.state(), 1)
+        self.assertEqual(self.ms._sw1.state(), 3)
+        self.assertEqual(self.ctrl.modules[1].pins[3].val, 1)
+        self.assertTrue(
+            all(led.val == (1 if idx == 3 else 0) for idx, led in enumerate(self.led_pins))
+        )
 
         self.ms.state(18)
-        self.assertEqual(self.main.state(), 4)
-        self.assertEqual(self.leds[18].val, 1)
-        self.assertEqual(self.s1.state(), 3)  # unchanged
-        self.assertEqual(self.s2.state(), 0)
+        self.assertEqual(self.ms._main.state(), 4)
+        self.assertEqual(self.ctrl.modules[2].pins[2].val, 1)
+        self.assertEqual(self.ms._sw1.state(), 3)  # unchanged
+        self.assertEqual(self.ms._sw2.state(), 0)
+        self.assertTrue(
+            all(led.val == (1 if idx == 18 else 0) for idx, led in enumerate(self.led_pins))
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- configure switch pins and LED mapping in `switch_config.yaml`
- load switch config via `_load_config` helper in `MultiSwitch`
- simplify test by using LED mapping from `MultiSwitch`
- restore root package init

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c107ab2f88324aa582ee32427228c